### PR TITLE
hotfix: Corrección de persistencia de la relación al crear un curso

### DIFF
--- a/src/models/course/course.services.ts
+++ b/src/models/course/course.services.ts
@@ -63,12 +63,21 @@ export class CourseService {
 
     const emFork = this.em.fork()
     
-    const professorRefFork = emFork.getReference(Professor, new ObjectId(professorId))
-    const courseTypeRefFork = emFork.getReference(CourseType, new ObjectId(courseTypeId))
-    const courseRefFork = emFork.getReference(Course, new ObjectId(course.id!))
+    const professor = await emFork.findOneOrFail(
+      Professor,
+      { _id: new ObjectId(professorId) },
+      { populate: ['courses'] }
+    );
+    const courseType = await emFork.findOneOrFail(
+      CourseType,
+      { _id: new ObjectId(courseTypeId) },
+      { populate: ['courses'] }
+    );
 
-    professorRefFork.courses.add(courseRefFork)
-    courseTypeRefFork.courses.add(courseRefFork)
+    const courseRef = emFork.getReference(Course, new ObjectId(course.id!));
+
+    professor.courses.add(courseRef)
+    courseType.courses.add(courseRef)
 
     await emFork.flush()
 


### PR DESCRIPTION
<!--
👋 ¡Gracias por tu contribución!
Completa la siguiente información para agilizar el proceso de revisión.
-->

### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
Closes #122 

---

### Resumen
<!--
Proporciona un resumen de 1-2 frases sobre el propósito principal de este Pull Request.
Ejemplo: "Este PR refactoriza el módulo `student` para alinearlo con la arquitectura moderna del proyecto."
-->
Este hotfix soluciona un `TypeError` crítico en el `CourseService` que impedía que las relaciones bidireccionales (entre Curso, Profesor y Tipo de Curso) se guardaran correctamente en la base de datos durante la creación de un nuevo curso.

### Cambios Técnicos Implementados
<!--
Describe en detalle los cambios que has realizado. Utiliza listas para una mayor claridad.
- **Validación:** Se ha añadido validación de entrada para `x` usando `y`.
- **Refactorización del Controlador:** Se ha aislado la lógica de negocio en el servicio, asegurando el uso de `await`.
- **Seguridad:** Se ha aplicado el `authMiddleware` a las nuevas rutas.
-->
- **Problema:** El método `create` del `CourseService`, en su segundo paso, intentaba añadir una referencia de curso a las colecciones `.courses` de `Professor` y `CourseType` que habían sido obtenidas con `em.getReference()`. Este método no inicializa las colecciones, resultando en `undefined` y provocando un error `TypeError: Cannot read properties of undefined (reading 'add')`.
- **Solución:** Se ha modificado la lógica para que, en lugar de `getReference`, se utilice `em.findOneOrFail()` con la opción `{ populate: ['courses'] }`. Esto asegura que las entidades `Professor` y `CourseType` se carguen completamente, con sus colecciones inicializadas y listas para ser modificadas, antes de añadir la nueva referencia del curso.

---

### Guía para Pruebas y Revisión
<!--
Describe los pasos exactos que el revisor debe seguir para verificar tus cambios. Incluye casos de éxito y de error.
-->
1.  Iniciar el servidor del backend.
2.  Utilizar el frontend (o un cliente de API) para crear un nuevo curso, asociándolo a un profesor y un tipo de curso existentes.
3.  **Verificar Éxito:** La petición debe completarse con un estado `201 Created`.
4.  **Verificar en Base de Datos:**
    - Revisar la colección `professors`. El documento del profesor correspondiente debe tener ahora el `ObjectId` del nuevo curso en su array `courses`.
    - Revisar la colección `coursetypes`. El documento del tipo de curso correspondiente debe tener ahora el `ObjectId` del nuevo curso en su array `courses`.
5.  **Verificar Regresión:** Confirmar que la vista "Mis Cursos" en el frontend ahora muestra el curso recién creado, validando que la relación se lee correctamente.