### PR TITLE
feat: Lógica "Recordarme" y corrección de Cookies en Producción

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -39,6 +39,8 @@ import { contactRouter } from './models/contact/contact.routes.js';
 export const createApp = (): Express => {
   const app = express();
 
+  app.set('trust proxy', 1);
+
   app.use(
     pinoHttp({
       logger,

--- a/src/auth/auth.controller.integration.spec.ts
+++ b/src/auth/auth.controller.integration.spec.ts
@@ -23,6 +23,7 @@ describe('AuthController Integration', () => {
 
   beforeEach(() => {
     mockReq = {
+      // Body original sin rememberMe
       body: { mail: 'test@test.com', password_plaintext: '123456' },
       log: { child: () => ({ info: jest.fn(), error: jest.fn() }) } as any 
     };
@@ -30,7 +31,8 @@ describe('AuthController Integration', () => {
     mockRes = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn(),
-      cookie: jest.fn(), // Mock cookie method
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
     };
     
     nextFn = jest.fn();
@@ -38,7 +40,6 @@ describe('AuthController Integration', () => {
   });
 
   it('Should integrate Controller and Service for a successful login', async () => {
-    // FIX: Update mock return to match new Service signature
     const mockTokens = { 
       accessToken: 'integration_access_token',
       refreshToken: 'integration_refresh_token'
@@ -51,9 +52,13 @@ describe('AuthController Integration', () => {
     await login(mockReq as Request, mockRes as Response, nextFn);
 
     // Verifications
-    expect(AuthService.prototype.login).toHaveBeenCalledWith(mockReq.body);
+    expect(AuthService.prototype.login).toHaveBeenCalledWith({
+      mail: 'test@test.com',
+      password_plaintext: '123456',
+      rememberMe: false 
+    });
     
-    // 1. Check Cookie was set (HttpOnly)
+    // 1. Check Cookie was set (HttpOnly) because refreshToken is present
     expect(mockRes.cookie).toHaveBeenCalledWith(
       'refreshToken', 
       'integration_refresh_token',


### PR DESCRIPTION
### Issue Relacionada
<!-- ¿Qué issue resuelve este PR? Utiliza "Closes" para que se cierre automáticamente. -->
No aplica

---

### Resumen
Este PR soluciona el problema de persistencia de sesión entre Vercel y Render configurando correctamente las cookies (`SameSite: 'none'`) y añade la funcionalidad de **"Recordarme"**, permitiendo al usuario decidir si desea una sesión persistente o temporal.

### Cambios Técnicos Implementados
- **Configuración de Cookies (Fix Producción):**
    - Se habilitó `app.set('trust proxy', 1)` en Express para que detecte correctamente el protocolo HTTPS detrás del balanceador de carga de Render.
    - Se actualizó la configuración de la cookie `refreshToken`: en producción ahora usa `SameSite: 'none'` y `Secure: true`, permitiendo la comunicación Cross-Site requerida por la arquitectura actual.
- **Lógica "Recordarme":**
    - Se modificó el `AuthService` para aceptar un parámetro `rememberMe`.
    - **Si es True:** Se genera un Refresh Token (guardado en BD y Cookie) y un Access Token de 15 minutos. Permite renovación automática.
    - **Si es False:** Se genera un Access Token de **3 horas** y **NO** se genera Refresh Token (ni se guarda en BD). La sesión expira definitivamente al terminar el tiempo.
- **Testing:** Se actualizaron los tests unitarios y de integración para incluir el parámetro `rememberMe` en las llamadas al servicio de autenticación.

---

### Guía para Pruebas y Revisión
1.  **Prueba de Cookies en Producción:**
    - Desplegar cambios.
    - Intentar login desde el Frontend (Vercel).
    - Verificar en DevTools -> Application -> Cookies que la cookie `refreshToken` se guarda correctamente (antes fallaba).
2.  **Prueba de Lógica "Recordarme" (Local):**
    - **Caso 1 (Sin check):** Hacer login. Verificar en jwt.io que el token dura 3 horas (`exp`). Verificar que **no** existe cookie `refreshToken`.
    - **Caso 2 (Con check):** Hacer login. Verificar en jwt.io que el token dura 15 minutos. Verificar que **sí** existe cookie `refreshToken`. Verificar en MongoDB que se creó el registro.